### PR TITLE
Show signs for messages after multi-message line.

### DIFF
--- a/plugin/markify.vim
+++ b/plugin/markify.vim
@@ -96,7 +96,7 @@ function! s:PlaceSigns(items) " {{{1
   for item in a:items
     if item.bufnr == 0 || item.lnum == 0 | continue | endif
     let id = item.bufnr . item.lnum
-    if has_key(s:sign_ids, id) | return | endif
+    if has_key(s:sign_ids, id) | continue | endif
     let s:sign_ids[id] = item
 
     let sign_name = ''


### PR DESCRIPTION
Previously, `s:PlaceSigns` returned upon encountering a second item on the same buffer/line.  The result was that subsequent items would not have a sign displayed next to them.  That behavior was undesirable because it gave the appearance that there were fewer items to handle than in fact there were.

Given the following setup consisting of a C source file `main.c` with errors on both lines of the `main` function and a makefile

```
// main.c
int main(int argc, char *argv[]) {
    return; return;
    return;
}

// makefile
build:
    cc main.c
```

executing `:make build<cr>` produces three items in the quickfix window, one for each `return` statement (because they aren't returning an expression and because the function has a non-`void` return type).  However, in vim-markify would only produce a single sign for the first `return`, resulting in the following being displayed:

```
   // main.c
   int main(int argc, char *argv[]) {
>>     return; return;
       return;
   }
```

Here, the implementation of `s:PlaceSigns` is changed so that upon encountering a second item on the same buffer/line as an already encountered item, rather than returning, it instead ignores the
"duplicate" item and proceeds to the next item in the list.  The resulting behavior is that every buffer/line for which there is an item will have a sign displayed next to it.  In the example above, executing `:make build<cr>` will display the following

```
   // main.c
   int main(int argc, char *argv[]) {
>>     return; return;
>>     return;
   }
```

The changed output makes it clear that there are errors on both lines of the function `main`.