### PR TITLE
Add pattern based error/warning detection

### DIFF
--- a/doc/markify.txt
+++ b/doc/markify.txt
@@ -29,8 +29,10 @@ OPTIONS							*markify-options*
 Overview :
 	|markify-error-text| .............. Define text for error sign
 	|markify-error-texthl| ............ Define texthl for error sign
+	|markify-error-pattern| ........... Define pattern identifying an error
 	|markify-warning-text| ............ Define text for error sign
 	|markify-warning-texthl| .......... Define texthl for error sign
+	|markify-warning-pattern| ......... Define pattern identifying a warning
 	|markify-info-text| ............... Define text for error sign
 	|markify-info-texthl| ............. Define texthl for error sign
 	|markify-autocmd| ................. Flag for enabling autocmd
@@ -49,6 +51,11 @@ g:markify_error_texthl					*markify-error-texthl*
 		let g:markify_error_texthl = 'Error'
 <
 
+g:markify_error_pattern					*markify-error-pattern*
+	Use this to define a pattern that identifies text as an error text.
+		let g:markify_error_pattern = '^ *error:'
+<
+
 g:markify_warning_text					*markify-warning-text*
 	Use this to define the this to define the text to use for warning
 	signs. >
@@ -58,6 +65,11 @@ g:markify_warning_text					*markify-warning-text*
 g:markify_warning_texthl				*markify-warning-texthl*
 	Use this to define the texthl to use for error signs. >
 		let g:markify_warning_texthl = 'Error'
+<
+
+g:markify_warning_pattern				*markify-warning-pattern*
+	Use this to define a pattern that identifies text as a warning text.
+		let g:markify_warning_pattern = '^ *warning:'
 <
 
 g:markify_info_text					*markify-info-text*

--- a/plugin/markify.vim
+++ b/plugin/markify.vim
@@ -48,8 +48,10 @@ endfunction
 " Set Global Default Options {{{1
 call s:SetGlobalOptDefault('markify_error_text', '>>')
 call s:SetGlobalOptDefault('markify_error_texthl', 'Error')
+call s:SetGlobalOptDefault('markify_error_pattern', '^ *error:')
 call s:SetGlobalOptDefault('markify_warning_text', '>>')
 call s:SetGlobalOptDefault('markify_warning_texthl', 'Todo')
+call s:SetGlobalOptDefault('markify_warning_pattern', '^ *warning:')
 call s:SetGlobalOptDefault('markify_info_text', '>>')
 call s:SetGlobalOptDefault('markify_info_texthl', 'Normal')
 call s:SetGlobalOptDefault('markify_autocmd', 1)
@@ -100,9 +102,9 @@ function! s:PlaceSigns(items) " {{{1
     let s:sign_ids[id] = item
 
     let sign_name = ''
-    if item.type ==? 'E'
+    if item.type ==? 'E' || item.text =~# g:markify_error_pattern
       let sign_name = 'MarkifyError'
-    elseif item.type ==? 'W'
+    elseif item.type ==? 'W' || item.text =~# g:markify_warning_pattern
       let sign_name = 'MarkifyWarning'
     else
       let sign_name = 'MarkifyInfo'


### PR DESCRIPTION
Currently we use item.type to identify an item as an error / warning. However,
this value isn't always populated. As a result, compilation often results with
all marks set to "info".

To fix this we add regex patterns that can identify the text itself as an error
/ warning.

These patterns are configurable, and default to '^ *error:' and '^ *warning:'
which work for g++ and clang.

NOTE: this can cause false-positive with, e.g., grep if the resulting line
starts with 'error:' / 'warning:'. If that happens, the grep result will be
marked as an error/warning instead of info.